### PR TITLE
merged get_transactions, get_date_object & get_month_transactions

### DIFF
--- a/comdirect_financialreport.py
+++ b/comdirect_financialreport.py
@@ -347,53 +347,7 @@ def delete_chart_image(chart_name):
 
 access_credentials = authenticate_api()
 finance_data = calculate_finance_report_data(access_credentials)
-# chart_name = create_graph(finance_data)
-# telegram_bot_send_text(current_month_report(finance_data))
-# telegram_bot_send_image(chart_name)
-# delete_chart_image(chart_name)
-
-
-# ----------------------------------------------------------------------------------------
-# test
-
-stamp = datetime.datetime.now()
-transactions = get_month_transactions(access_credentials, stamp)
-
-
-import pandas as pd
-
-def convert2dataframe(transactions, clm):
-    df = []
-    for transaction in transactions:
-        text = ''
-        if transaction['remitter'] is not None:
-            # text += 'Auftraggeber: ' + transaction['remitter']['holderName'] + ' '
-            text += transaction['remitter']['holderName'] + ' ' 
-        if transaction['creditor'] is not None:
-            # text += 'Empfänger: ' + transaction['creditor']['holderName'] + ' '
-            text += transaction['creditor']['holderName'] + ' '
-        # text += 'Buchungstext: ' + transaction['remittanceInfo'] + ' '
-        text += transaction['remittanceInfo'] + ' '
-        # text += 'Ref. ' + transaction['reference']
-
-        df.append([ transaction['bookingDate'], transaction['transactionType']['text'], text, transaction["amount"]["value"] ])
-    
-    df = pd.DataFrame(df, columns=[clm['date'], clm['type'], clm['text'], clm['amount']])
-
-    df[clm['date']]   = pd.to_datetime( df[clm['date']] , format='%Y-%m-%d', errors='coerce' )
-    df[clm['amount']] = df[clm['amount']].astype(float)
-
-    df = df.sort_values(by=[clm['date']], ascending=False)
-    return df
-
-
-clm = dict(
-    date     = 'Datum'        ,
-    type     = 'Vorgang'      ,
-    text     = 'Buchungstext' ,
-    amount   = 'Betrag'       ,
-    )
-
-df = convert2dataframe(transactions, clm)
-
-print(df.head(10))
+chart_name = create_graph(finance_data)
+telegram_bot_send_text(current_month_report(finance_data))
+telegram_bot_send_image(chart_name)
+delete_chart_image(chart_name)


### PR DESCRIPTION
Hi!
While adapting your code to my project (https://github.com/gerritnowald/budget_book), I realized that the functions get_transactions, get_date_object & get_month_transactions can be merged, to make the code shorter and more concise.
get_date_object is only needed because the date format is defined differently in get_month_transactions.
Then get_month_transactions basically is just a wrapper for get_transactions, which is not used anywhere else, so they can be merged.
Also I replaced the while loop with a for loop.

I tested it by converting my transactions to a dataframe and displaying it.
I did not test the figure creation & signal bot parts, but they should still work if the output from get_month_transactions is the same.